### PR TITLE
  - wheelcc last update

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ For projects hosted elsewhere, use this format:
 
 * [LesleyLai/mcc](https://github.com/LesleyLai/mcc) - A C23 implementation. While loosely following the book, I also consulted other resources, and this implementation has notable deviations, including a handwritten lexer, name resolution within the parser, and a slightly different IR design.
 
+* [romainducrocq/wheelcc](https://github.com/romainducrocq/wheelcc) - An ISO C17 implementation for Linux and MacOS that depends only on Glibc, POSIX and bash. It covers 100% of the book (parts 1-3 + extra-credits, passes all the tests), with additions such as a handwritten lexer, support for includes and comprehensive error messages. The design follows the book, but many details have been changed and some compiler stages were combined. The project also builds in C++.
+
 ## C++
 
 * [Gnomeball/C-Compiler](https://github.com/Gnomeball/C-Compiler) - Implemented on Linux; only notable change from the intended design is the use of a byte code representation instead of an AST while parsing; so far only chapter one is 'complete', though it's extremely rough.
-
-* [romainducrocq/wheelcc](https://github.com/romainducrocq/wheelcc) - C++17 implementation for Linux and MacOS: has a handwritten lexer with builtin preprocessing, comprehensive error messages with source locations and zero dependencies other than gcc. Covers 100% of the book and passes 100% of the test-suite (Parts 1, 2, 3 and extra-credits). While the overall design follows the book, many implementation details have been changed in all parts. I am currently migrating the project to C.
 
 * [Sh0g0-1758/scarlet](https://github.com/Sh0g0-1758/scarlet) - C++ (>=20) implementation featuring multiline error recovery and CI-verified builds. Completed Part 1 with all extra credits. Implementation largely follows the book with deviations in semantic analysis stage. Parts 2/3 in active development targeting x86_64 (Linux/macOS). Roadmap includes extensive static analysis optimizations and a future machine learning framework. Built with CMake and tested across GCC/Clang.
 
@@ -64,7 +64,7 @@ For projects hosted elsewhere, use this format:
 
 ## Cython
 
-* [romainducrocq/cube](https://github.com/romainducrocq/cube) - An early version of [romainducrocq/wheelcc](https://github.com/romainducrocq/wheelcc) that implements chapters 1 to 13, before switching the compiler implementation to C++. It is discontinued and will no longer receive updates.
+* [romainducrocq/cube](https://github.com/romainducrocq/cube) - An early version of [romainducrocq/wheelcc](https://github.com/romainducrocq/wheelcc) that implements chapters 1 to 13, before switching the compiler implementation to C/C++. It will no longer receive updates.
 
 ## Go
 


### PR DESCRIPTION
After finishing my implementation of `wheelcc` in C++, I felt like the project could still be pushed a little further. Indeed, isn’t the goal of this project to learn more about the C language as a whole? So why not have the compiler itself written in C?

Thus, I migrated `wheelcc` from C++ to C, and more specifically to ISO C17 to be as close to the target language as possible. What I mean by ISO C17 is that the compiler is built with `gcc -std=c17 -Wall -Wextra -Werror -Wpedantic -pedantic-errors`. 

I also made sure that the project stays a valid C++ codebase (because why not?), so it can be built with both `gcc -std=c17` and `g++ -std=c++17` (hence, no use of C-only features like VLAs, designated initializers, setjmp/longjmp, etc… ). The project is now entirely written in the subset that is both valid ISO C17 and C++17.

Let’s note that this is not a full rewrite of the compiler, rather I went over each part relying on C++ one-by-one and changed them to C until I could build the entire project with `gcc -std=c17`.

The major changes in the new C implementation are:
- User errors are now handled with return error codes + goto early cleanup and exit (instead of throwing exceptions in C++).
- 2 widely adopted open-source libraries are used for data collections: [antirez/sds](https://github.com/antirez/sds) for dynamic strings and [nothings/stb_ds](https://github.com/nothings/stb/blob/master/stb_ds.h) for dynamic arrays and hashmaps (instead of native std::string, std::vector, std::unordered_map and std::unordered_set in C++). I patched these two libraries quite a bit to have them work in both C and C++, and added hashsets.
- Memory is managed manually with a bunch of homemade boilerplate and reference counting (instead of automatic memory management with std::unique_ptr and std::shared_ptr in C++). I validated this part by automating valgrind over your test-suite and my own tests. There are no leaks or errors reported, so as far as I can tell the memory is sane. 
- The Ast is represented with tagged unions (instead of class inheritance with runtime polymorphism in C++). Nodes are allocated on the heap and pointers to child nodes are shared between multiple parents when it makes sense. Except for atomic nodes like UnaryOp and BinaryOp, which are on the stack.

Performance wise, I developed almost all the project on my crappy 8 years old potato laptop with 8Gb of RAM, 8th gen i5 core on Debian stable and everything runs very fast and smoothly. The heap usage is on average in the ballpark of 10KB-100KB for most tests, and it hits 1MB for the biggest/most complex tests from chapter 18 when all optimization passes are enabled. It could probably be improved, but it's quite okay.

The old C++ implementation can still be found in the repo at tag `0.1.1` and the new C version starts from tag `0.2.0`. 

Another small but flashy improvement is that while the error messages previously displayed the line where the error occurred, they now highlight the exact token causing the error.
For example, the program:
```c
int main(void) {
    return 1 + foo;
}
```
outputs the error message:
```
/home/romain/proj/main.c:2:16:
error: (no. 564) variable ‘foo’ not declared in this scope
at line 2:                v~~
         |     return 1 + foo;
wheelcc: error: compilation failed, see ‘--help’
```

That’s it for the migration to C and I guess for this whole project. I went as far as I had envisioned at the start and I have other language and compiler projects in mind that I want to spend time on, so this will be my last update here.
I don’t exclude that I will come back to the project at some point, because it has A LOT of potential for further exploration. But anything after this point would be out of the scope of the book so I’ll advertise it on my own Github and not on this page.

I am sure that your work will inspire many young developers to learn more about compilers, so really thank you for that.
